### PR TITLE
Add missing url to vendored nodebb-theme-harmony metadata

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.35/plugin.json
+++ b/vendor/nodebb-theme-harmony-2.1.35/plugin.json
@@ -1,5 +1,6 @@
 {
 	"id": "nodebb-theme-harmony",
+	"url": "https://github.com/NodeBB/nodebb-theme-harmony",
 	"hooks": [
 		{ "hook": "static:app.load", "method": "init" },
 		{ "hook": "filter:admin.header.build", "method": "addAdminNavigation" },


### PR DESCRIPTION
Link to the associated GitHub issues:
https://github.com/CMU-313/nodebb-spring-26-f2/issues/15

Full path to the refactored files:
vendor/nodebb-theme-harmony-2.1.35/plugin.json

This change adds the url to the node bb harmony metadata to pass a check previously the solely failing one.

Without this change we would fail a CI test

To implement we added the nodebb harmony link to the metadata.

It was tested through the github CI check which all passed 

