### PR TITLE
Updated Translator API Endpoint

### DIFF
--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -2,7 +2,7 @@
 //var request = require('request');
 
 const translatorApi = module.exports;
-const DEFAULT_TRANSLATOR_API = 'http://127.0.0.1:5000';
+const DEFAULT_TRANSLATOR_API = 'http://17313-team17.s3d.cmu.edu:500';
 
 translatorApi.translate = async function (postData) {
 	const content = (postData && typeof postData.content === 'string') ? postData.content : '';

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -2,7 +2,7 @@
 //var request = require('request');
 
 const translatorApi = module.exports;
-const DEFAULT_TRANSLATOR_API = 'http://17313-team17.s3d.cmu.edu:500';
+const DEFAULT_TRANSLATOR_API = 'http://17313-team17.s3d.cmu.edu:5000';
 
 translatorApi.translate = async function (postData) {
 	const content = (postData && typeof postData.content === 'string') ? postData.content : '';


### PR DESCRIPTION
The translator API was set to localhost (127.0.0.1) with a port typo (:5000), which caused connection failures between NodeBB and the Python microservice in the deployed environment. It was updated in src/translate/index.js to use the server URL: http://17313-team17.s3d.cmu.edu:5000.