### PR TITLE
Add extra_hosts to resolve VM hostname from NodeBB container

### DIFF
--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -6,6 +6,8 @@ services:
     build: .
     # image: ghcr.io/nodebb/nodebb:latest
     restart: unless-stopped
+    extra_hosts:
+      - "17313-team17.s3d.cmu.edu:host-gateway"
     ports:
       - '4567:4567' # comment this out if you don't want to expose NodeBB to the host, or change the first number to any port you want
     volumes:


### PR DESCRIPTION
edited the local translator url to the deployed url so that deployed nodebb can call the deployed translator microservice and added to docker compose file to vm could access the deployed link