### PR TITLE
Fix test timeout by mocking translator

### DIFF
--- a/test/mocks/databasemock.js
+++ b/test/mocks/databasemock.js
@@ -128,6 +128,12 @@ winston.info('database config %s', dbType, testDbConfig);
 winston.info(`environment ${global.env}`);
 
 const db = require('../../src/database');
+const translator = require('../../src/translate');
+
+translator.translate = async function (postData) {
+	const content = (postData && typeof postData.content === 'string') ? postData.content : '';
+	return [true, content];
+};
 
 module.exports = db;
 


### PR DESCRIPTION
**Description**

This PR resolves a timeout in  test/controllers.js (category controller test: "should create 2 pages of topics"). The issue was caused by repeated external calls to the translator microservice during post creation. Since this test creates multiple topics, it triggered multiple network requests, causing the test to exceed the timeout limit.

**Fix**

We override the translator function in the test environment to return a fixed response ([true, content]) instead of making external API calls. This removes the dependency on the deployed service during tests.

**Why mocking is okay here**
The failing test is intended to verify category and pagination behavior not translation correctness. Mocking ensures tests remain fast and focused on the functionality being tested. The translator service can be tested separately.

**Testing**

- Ran npm test
- Verified timeout issue is resolved 
